### PR TITLE
Add Codecov API token to README update script

### DIFF
--- a/.github/workflows/_bump_version.yaml
+++ b/.github/workflows/_bump_version.yaml
@@ -47,6 +47,8 @@ jobs:
         run: |
           ./scripts/chores/sync_readme.sh \
             "${{ steps.plan.outputs.version }}"
+        env:
+          CODECOV_API_TOKEN: ${{ secrets.CODECOV_API_TOKEN }}
 
       - name: Commit Version Bump
         run: |

--- a/scripts/shared/poke.api.sh
+++ b/scripts/shared/poke.api.sh
@@ -106,12 +106,7 @@ function __poke_api__get_pokemon() {
   local api_response release_count url
 
   release_count="$(manifest_get releases)"
-
-  if [[ -n "$version" ]]; then
-    __out__[tag]="v${version#v}"  # Normalize: strip v if present, then add it
-  else
-    __out__[tag]="v$(manifest_get stable)"
-  fi
+  __out__[tag]="v$(manifest_get stable)"
 
   if [[ -z "$release_count" || "$release_count" == "0" ]]; then
     __out__[release_number]="???"


### PR DESCRIPTION
This pull request contains two small changes: one to the CI workflow configuration and one to a shell script. The workflow now sets the `CODECOV_API_TOKEN` environment variable for a step, and the shell script simplifies how the release tag is determined.

* CI/CD configuration:
  * Added the `CODECOV_API_TOKEN` environment variable to the environment for the README sync step in `.github/workflows/_bump_version.yaml`.

* Script simplification:
  * Simplified the logic in `scripts/shared/poke.api.sh` to always set the tag to the stable version from the manifest, removing conditional handling of the `version` variable.