### PR TITLE
Remove Bash coverage reporting

### DIFF
--- a/scripts/shared/poke.api.sh
+++ b/scripts/shared/poke.api.sh
@@ -56,8 +56,8 @@ $POKE_START
     <tr>
       <td>Bash</td>
       <td>${__poke_info__[bash_loc]}</td>
-      <td>${__poke_info__[bash_unit_coverage]}</td>
-      <td>Line</td>
+      <td>N/A</td>
+      <td>N/A</td>
     </tr>
   </table>
 </div>
@@ -179,9 +179,6 @@ function __poke_api__get_coverage() {
     __out__[go_unit_coverage]="N/A"
     __out__[rust_unit_coverage]="N/A"
   fi
-
-  # TODO - actually add bash coverage
-  __out__[bash_unit_coverage]="0%"  # No bash coverage tooling
 }
 
 : <<'DOC'


### PR DESCRIPTION
This pull request makes a minor update to how Bash coverage information is displayed in the `scripts/shared/poke.api.sh` script. The change removes the placeholder and "Line" coverage type for Bash, replacing them with "N/A" to clearly indicate that Bash coverage is not available.

* The Bash coverage columns in the output table now display "N/A" instead of a placeholder value and coverage type.
* The placeholder assignment for Bash unit coverage (`"0%"`) has been removed from the `__poke_api__get_coverage` function, along with the related TODO comment.