### PR TITLE
Add dependabot version updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -2,15 +2,41 @@ version: 2
 updates:
 - package-ecosystem: "cargo"
   directory: "crates/"
+  assignees:
+    - jerrod-storm
+  labels:
+    - dependencies
+    - rust
+    - chore
+  ignore:
+    - dependency-name: "*"
+      update-types:
+        - version-update:semver-major
   schedule:
     interval: weekly
 
 - package-ecosystem: "go"
   directory: "go/"
+  assignees:
+    - jerrod-storm
+  labels:
+    - dependencies
+    - go
+    - chore
+  ignore:
+    - dependency-name: "*"
+      update-types:
+        - version-update:semver-major
   schedule:
     interval: weekly
 
 - package-ecosystem: "github-actions"
   directory: "/"
+  assignees:
+    - jerrod-storm
+  labels:
+    - dependencies
+    - ci
+    - chore
   schedule:
     interval: monthly


### PR DESCRIPTION
This pull request introduces a new `.github/dependabot.yaml` configuration file to automate dependency updates for Rust, Go, and GitHub Actions projects. The configuration specifies update schedules, responsible assignees, relevant labels, and rules to ignore major version updates for dependencies.

Dependency update automation:

* Added `.github/dependabot.yaml` to enable Dependabot for Rust (`crates/`), Go (`go/`), and GitHub Actions (`/`) directories, with weekly updates for Rust and Go, and monthly updates for GitHub Actions.
* Configured dependency update assignments to `jerrod-storm` and labeled updates appropriately for each ecosystem (e.g., `dependencies`, `rust`, `go`, `ci`, `chore`).
* Set rules to ignore major version updates for all dependencies, reducing the risk of breaking changes from automatic updates.