### PR TITLE
Fix broken path to sub-workflow

### DIFF
--- a/.github/workflows/manual-release.yaml
+++ b/.github/workflows/manual-release.yaml
@@ -24,7 +24,7 @@ on:
 jobs:
   validate:
     if: ${{ !inputs.skip_validation }}
-    uses: ./.github/workflows/_validate_release.yaml
+    uses: ./.github/workflows/_validate.yaml
     secrets: inherit
 
   bump:

--- a/kaitos.json
+++ b/kaitos.json
@@ -1,7 +1,7 @@
 {
   "repo": "kaitos-toolchain",
   "org": "kernelle-soft",
-  "latest": "0.0.7",
+  "latest": "0.0.8-dev.1",
   "stable": "0.0.7",
   "releases": 7,
   "naming": {


### PR DESCRIPTION
This pull request includes minor updates to the release workflow and project metadata. The most important changes are:

Release workflow update:

* [`.github/workflows/manual-release.yaml`](diffhunk://#diff-ba764e03d0b13a57755ef0e32238d5c99aee428268ac08bd62160f5ee6bbd1c1L27-R27): Updated the validation job to use the correct reusable workflow file (`_validate.yaml` instead of `_validate_release.yaml`).

Project metadata update:

* [`kaitos.json`](diffhunk://#diff-59a2ad32244f5beac9c14a77511e44e030ab7c805f84de63ca0ac2bca1645fa3L4-R4): Bumped the `latest` version to `0.0.8-dev.1` to reflect the new development release.