### PR TITLE
Add a watch job for development

### DIFF
--- a/justfile
+++ b/justfile
@@ -27,3 +27,13 @@ build *args:
 
 release *args:
   ./scripts/chores/build.sh --release --bundle {{args}}
+
+watch *args:
+  watchexec \
+    --restart \
+    --clear \
+    --exts go,rs,toml \
+    --watch go \
+    --watch crates \
+    -i 'crates/target/**' \
+    -- just build {{args}}

--- a/scripts/chores/install_tools.sh
+++ b/scripts/chores/install_tools.sh
@@ -38,6 +38,7 @@ declare -A INSTALLERS=(
   [tokei]="cargo binstall -y --locked --force tokei@14.0.0"
   [cargo-llvm-cov]="cargo binstall -y --locked --force cargo-llvm-cov@0.6.24"
   [cargo-audit]="cargo binstall -y --locked --force cargo-audit@0.22.0"
+  [watchexec]="cargo binstall -y --locked --force watchexec-cli@2.3.3"
 )
 
 declare -A UNINSTALLERS=(
@@ -47,6 +48,7 @@ declare -A UNINSTALLERS=(
   [tokei]="cargo uninstall -v tokei"
   [cargo-llvm-cov]="cargo uninstall -v cargo-llvm-cov"
   [cargo-audit]="cargo uninstall -v cargo-audit"
+  [watchexec]="cargo uninstall -v watchexec-cli"
   [cargo-binstall]="cargo uninstall -v cargo-binstall"
 )
 


### PR DESCRIPTION
This pull request adds support for a new file-watching workflow to streamline development and ensures the necessary tool is included in the project's toolchain management scripts. The key changes are grouped below:

**Development workflow improvements:**

* Added a new `watch` recipe to the `justfile` that uses `watchexec` to automatically rebuild the project when files in `go`, `crates`, or relevant extensions change, improving the developer experience by enabling live rebuilds.

**Toolchain management updates:**

* Updated `scripts/chores/install_tools.sh` to install `watchexec-cli` using `cargo binstall`, ensuring the watch functionality is available for all developers.
* Updated the same script to uninstall `watchexec-cli` when cleaning up tools, keeping tool management consistent.