### PR TITLE
Create script to sync project manifest of docs site

### DIFF
--- a/.github/workflows/_bump_version.yaml
+++ b/.github/workflows/_bump_version.yaml
@@ -66,6 +66,11 @@ jobs:
         env:
           CODECOV_API_TOKEN: ${{ secrets.CODECOV_API_TOKEN }}
 
+      - name: Sync Docs Version
+        run: |
+          ./scripts/chores/sync_docs_version.sh \
+            "${{ steps.plan.outputs.version }}"
+
       - name: Commit Version Bump
         run: |
           ./scripts/ci/git_commit.sh -a \

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "ecs"
-version = "0.0.8-dev.5"
+version = "0.0.8-dev.7"
 dependencies = [
  "hecs",
 ]
@@ -17,7 +17,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "godot"
-version = "0.0.8-dev.5"
+version = "0.0.8-dev.7"
 
 [[package]]
 name = "hashbrown"
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.0.8-dev.5"
+version = "0.0.8-dev.7"
 
 [[package]]
 name = "spin"

--- a/scripts/chores/sync_docs_version.sh
+++ b/scripts/chores/sync_docs_version.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+eval "${CI_ENVRC:-}"
+
+USAGE="$(cat <<EOF
+Syncs the docs site version (site/package.json) to the canonical project version.
+
+Usage: sync_docs_version.sh [version]
+
+Arguments:
+  version     Optional semver version to use (e.g., 1.2.3 or 1.0.0-rc.1)
+              If not provided, reads the current version from git tags.
+
+Flags:
+  -h, --help  Show this help text
+EOF
+)"
+
+ARG_VERSION=""
+
+import "$REPO_ROOT/scripts/shared/versions.api.sh"
+
+PATH_DOCS_PACKAGE="$REPO_ROOT/site/package.json"
+
+function main() {
+  local current_version old_version
+
+  parse_args "$@"
+
+  if [[ -n "$ARG_VERSION" ]]; then
+    current_version="$ARG_VERSION"
+  else
+    current_version="$(latest_version)"
+  fi
+
+  old_version="$(jq -r '.version' "$PATH_DOCS_PACKAGE")"
+
+  if [[ "$current_version" = "$old_version" ]]; then
+    log "Docs site is up-to-date with version '$current_version'"
+    exit 0
+  fi
+
+  local temp_file
+  temp_file="$(mktemp)"
+  jq --arg v "$current_version" '.version = $v' "$PATH_DOCS_PACKAGE" > "$temp_file"
+  mv "$temp_file" "$PATH_DOCS_PACKAGE"
+
+  log "Successfully updated site/package.json to '$current_version'"
+}
+
+: <<'DOC'
+  Parses CLI flags.
+  See USAGE for flag descriptions.
+DOC
+function parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help)  log "$USAGE" && exit 0;;
+      -*)
+        log "Unknown option: $1"
+        log "$USAGE"
+        exit 1
+        ;;
+      *)
+        if ! is_valid_semver "$1"; then
+          log "Invalid semver: $1"
+          log "$USAGE"
+          exit 1
+        fi
+        ARG_VERSION="$1"
+        ;;
+    esac
+    shift
+  done
+}
+
+main "$@"

--- a/site/package.json
+++ b/site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docs",
   "type": "module",
-  "version": "0.0.1",
+  "version": "0.0.8-dev.7",
   "private": true,
   "packageManager": "pnpm@10.30.0",
   "scripts": {


### PR DESCRIPTION
This pull request introduces automation to keep the documentation site's version in sync with the project's canonical version during the version bump workflow. The main changes are the addition of a new script for syncing the docs version, integration of this script into the CI workflow, and an update to the docs site version.

Automation for docs version synchronization:

* Added `scripts/chores/sync_docs_version.sh`, a script that updates the `site/package.json` version to match the project version, accepting a semver argument or inferring from git tags.
* Integrated the new script into the `.github/workflows/_bump_version.yaml` workflow, ensuring the docs version is updated automatically during version bumps.

Documentation version update:

* Updated the `site/package.json` version from `0.0.1` to `0.0.8-dev.7`