### PR TITLE
Update devalue to 5.6.3

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@astrojs/mdx": "^4.3.13",
     "@astrojs/starlight": "^0.37.6",
-    "astro": "^5.6.1",
-    "sharp": "^0.34.2"
+    "astro": "^5.17.3",
+    "sharp": "^0.34.5"
   }
 }

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -10,15 +10,15 @@ importers:
     dependencies:
       '@astrojs/mdx':
         specifier: ^4.3.13
-        version: 4.3.13(astro@5.17.2(rollup@4.57.1)(typescript@5.9.3))
+        version: 4.3.13(astro@5.17.3(rollup@4.57.1)(typescript@5.9.3))
       '@astrojs/starlight':
         specifier: ^0.37.6
-        version: 0.37.6(astro@5.17.2(rollup@4.57.1)(typescript@5.9.3))
+        version: 0.37.6(astro@5.17.3(rollup@4.57.1)(typescript@5.9.3))
       astro:
-        specifier: ^5.6.1
-        version: 5.17.2(rollup@4.57.1)(typescript@5.9.3)
+        specifier: ^5.17.3
+        version: 5.17.3(rollup@4.57.1)(typescript@5.9.3)
       sharp:
-        specifier: ^0.34.2
+        specifier: ^0.34.5
         version: 0.34.5
 
 packages:
@@ -820,8 +820,8 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  acorn@8.15.0:
-    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -866,8 +866,8 @@ packages:
     peerDependencies:
       astro: ^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta
 
-  astro@5.17.2:
-    resolution: {integrity: sha512-7jnMqGo53hOQNwo1N/wqeOvUp8wwW/p+DeerSjSkHNx8L/1mhy6P7rVo7EhdmF8DpKqw0tl/B5Fx1WcIzg1ysA==}
+  astro@5.17.3:
+    resolution: {integrity: sha512-69dcfPe8LsHzklwj+hl+vunWUbpMB6pmg35mACjetxbJeUNNys90JaBM8ZiwsPK689SAj/4Zqb1ayaANls9/MA==}
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
 
@@ -1013,8 +1013,8 @@ packages:
     resolution: {integrity: sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==}
     engines: {node: '>=18'}
 
-  devalue@5.6.2:
-    resolution: {integrity: sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==}
+  devalue@5.6.3:
+    resolution: {integrity: sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg==}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -1142,8 +1142,8 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  get-east-asian-width@1.4.0:
-    resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
+  get-east-asian-width@1.5.0:
+    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
     engines: {node: '>=18'}
 
   github-slugger@2.0.0:
@@ -2032,12 +2032,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@4.3.13(astro@5.17.2(rollup@4.57.1)(typescript@5.9.3))':
+  '@astrojs/mdx@4.3.13(astro@5.17.3(rollup@4.57.1)(typescript@5.9.3))':
     dependencies:
       '@astrojs/markdown-remark': 6.3.10
       '@mdx-js/mdx': 3.1.1
-      acorn: 8.15.0
-      astro: 5.17.2(rollup@4.57.1)(typescript@5.9.3)
+      acorn: 8.16.0
+      astro: 5.17.3(rollup@4.57.1)(typescript@5.9.3)
       es-module-lexer: 1.7.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -2061,17 +2061,17 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 3.25.76
 
-  '@astrojs/starlight@0.37.6(astro@5.17.2(rollup@4.57.1)(typescript@5.9.3))':
+  '@astrojs/starlight@0.37.6(astro@5.17.3(rollup@4.57.1)(typescript@5.9.3))':
     dependencies:
       '@astrojs/markdown-remark': 6.3.10
-      '@astrojs/mdx': 4.3.13(astro@5.17.2(rollup@4.57.1)(typescript@5.9.3))
+      '@astrojs/mdx': 4.3.13(astro@5.17.3(rollup@4.57.1)(typescript@5.9.3))
       '@astrojs/sitemap': 3.7.0
       '@pagefind/default-ui': 1.4.0
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 5.17.2(rollup@4.57.1)(typescript@5.9.3)
-      astro-expressive-code: 0.41.6(astro@5.17.2(rollup@4.57.1)(typescript@5.9.3))
+      astro: 5.17.3(rollup@4.57.1)(typescript@5.9.3)
+      astro-expressive-code: 0.41.6(astro@5.17.3(rollup@4.57.1)(typescript@5.9.3))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -2418,7 +2418,7 @@ snapshots:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdx': 2.0.13
-      acorn: 8.15.0
+      acorn: 8.16.0
       collapse-white-space: 2.1.0
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
@@ -2427,7 +2427,7 @@ snapshots:
       hast-util-to-jsx-runtime: 2.3.6
       markdown-extensions: 2.0.0
       recma-build-jsx: 1.0.0
-      recma-jsx: 1.0.1(acorn@8.15.0)
+      recma-jsx: 1.0.1(acorn@8.16.0)
       recma-stringify: 1.0.0
       rehype-recma: 1.0.0
       remark-mdx: 3.1.1
@@ -2620,11 +2620,11 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  acorn-jsx@5.3.2(acorn@8.15.0):
+  acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.16.0
 
-  acorn@8.15.0: {}
+  acorn@8.16.0: {}
 
   ansi-align@3.0.1:
     dependencies:
@@ -2651,12 +2651,12 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.41.6(astro@5.17.2(rollup@4.57.1)(typescript@5.9.3)):
+  astro-expressive-code@0.41.6(astro@5.17.3(rollup@4.57.1)(typescript@5.9.3)):
     dependencies:
-      astro: 5.17.2(rollup@4.57.1)(typescript@5.9.3)
+      astro: 5.17.3(rollup@4.57.1)(typescript@5.9.3)
       rehype-expressive-code: 0.41.6
 
-  astro@5.17.2(rollup@4.57.1)(typescript@5.9.3):
+  astro@5.17.3(rollup@4.57.1)(typescript@5.9.3):
     dependencies:
       '@astrojs/compiler': 2.13.1
       '@astrojs/internal-helpers': 0.7.5
@@ -2665,7 +2665,7 @@ snapshots:
       '@capsizecss/unpack': 4.0.0
       '@oslojs/encoding': 1.1.0
       '@rollup/pluginutils': 5.3.0(rollup@4.57.1)
-      acorn: 8.15.0
+      acorn: 8.16.0
       aria-query: 5.3.2
       axobject-query: 4.1.0
       boxen: 8.0.1
@@ -2676,7 +2676,7 @@ snapshots:
       cssesc: 3.0.0
       debug: 4.4.3
       deterministic-object-hash: 2.0.2
-      devalue: 5.6.2
+      devalue: 5.6.3
       diff: 8.0.3
       dlv: 1.1.3
       dset: 3.1.4
@@ -2873,7 +2873,7 @@ snapshots:
     dependencies:
       base-64: 1.0.0
 
-  devalue@5.6.2: {}
+  devalue@5.6.3: {}
 
   devlop@1.1.0:
     dependencies:
@@ -2925,7 +2925,7 @@ snapshots:
   esast-util-from-js@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
-      acorn: 8.15.0
+      acorn: 8.16.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
 
@@ -3052,7 +3052,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  get-east-asian-width@1.4.0: {}
+  get-east-asian-width@1.5.0: {}
 
   github-slugger@2.0.0: {}
 
@@ -3642,8 +3642,8 @@ snapshots:
 
   micromark-extension-mdxjs@3.0.0:
     dependencies:
-      acorn: 8.15.0
-      acorn-jsx: 5.3.2(acorn@8.15.0)
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
       micromark-extension-mdx-expression: 3.0.1
       micromark-extension-mdx-jsx: 3.0.2
       micromark-extension-mdx-md: 2.0.0
@@ -3913,10 +3913,10 @@ snapshots:
       estree-util-build-jsx: 3.0.1
       vfile: 6.0.3
 
-  recma-jsx@1.0.1(acorn@8.15.0):
+  recma-jsx@1.0.1(acorn@8.16.0):
     dependencies:
-      acorn: 8.15.0
-      acorn-jsx: 5.3.2(acorn@8.15.0)
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
       estree-util-to-js: 2.0.0
       recma-parse: 1.0.0
       recma-stringify: 1.0.0
@@ -4175,7 +4175,7 @@ snapshots:
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.6.0
-      get-east-asian-width: 1.4.0
+      get-east-asian-width: 1.5.0
       strip-ansi: 7.1.2
 
   stringify-entities@4.0.4:


### PR DESCRIPTION
This pull request updates several dependencies in the `site` project to address minor version bumps and ensure compatibility with the latest releases. The changes primarily affect `astro`, `sharp`, and related packages, as well as their transitive dependencies. No functional code changes are included; this is a routine maintenance update to keep the project up-to-date and resolve a low-risk CVE

Dependency updates:

* Updated `astro` from version `5.17.2`/`5.6.1` to `5.17.3` in `package.json` and `pnpm-lock.yaml`, along with related snapshots and dependency trees. [[1]](diffhunk://#diff-35f15d66f9b39b506a11ac9b5c6b9a80e11b41bfd56832ab130372902258ccf7L17-R18) [[2]](diffhunk://#diff-28fd666fc4ef5763e442c8dab8ee5f27ef99c81eafb4d9779bed158340267859L13-R21) [[3]](diffhunk://#diff-28fd666fc4ef5763e442c8dab8ee5f27ef99c81eafb4d9779bed158340267859L869-R870) [[4]](diffhunk://#diff-28fd666fc4ef5763e442c8dab8ee5f27ef99c81eafb4d9779bed158340267859L2654-R2659)
* Updated `sharp` from `0.34.2` to `0.34.5` in `package.json` and `pnpm-lock.yaml`. [[1]](diffhunk://#diff-35f15d66f9b39b506a11ac9b5c6b9a80e11b41bfd56832ab130372902258ccf7L17-R18) [[2]](diffhunk://#diff-28fd666fc4ef5763e442c8dab8ee5f27ef99c81eafb4d9779bed158340267859L13-R21)
* Updated `acorn` from `8.15.0` to `8.16.0` and propagated this change to all packages and snapshots that reference it, including `acorn-jsx`, `recma-jsx`, and other dependencies. [[1]](diffhunk://#diff-28fd666fc4ef5763e442c8dab8ee5f27ef99c81eafb4d9779bed158340267859L823-R824) [[2]](diffhunk://#diff-28fd666fc4ef5763e442c8dab8ee5f27ef99c81eafb4d9779bed158340267859L2421-R2421) [[3]](diffhunk://#diff-28fd666fc4ef5763e442c8dab8ee5f27ef99c81eafb4d9779bed158340267859L2430-R2430) [[4]](diffhunk://#diff-28fd666fc4ef5763e442c8dab8ee5f27ef99c81eafb4d9779bed158340267859L2623-R2627) [[5]](diffhunk://#diff-28fd666fc4ef5763e442c8dab8ee5f27ef99c81eafb4d9779bed158340267859L2928-R2928) [[6]](diffhunk://#diff-28fd666fc4ef5763e442c8dab8ee5f27ef99c81eafb4d9779bed158340267859L3645-R3646) [[7]](diffhunk://#diff-28fd666fc4ef5763e442c8dab8ee5f27ef99c81eafb4d9779bed158340267859L3916-R3919) [[8]](diffhunk://#diff-28fd666fc4ef5763e442c8dab8ee5f27ef99c81eafb4d9779bed158340267859L2668-R2668)
* Updated `devalue` from `5.6.2` to `5.6.3` and propagated this change to all relevant snapshots. [[1]](diffhunk://#diff-28fd666fc4ef5763e442c8dab8ee5f27ef99c81eafb4d9779bed158340267859L1016-R1017) [[2]](diffhunk://#diff-28fd666fc4ef5763e442c8dab8ee5f27ef99c81eafb4d9779bed158340267859L2679-R2679) [[3]](diffhunk://#diff-28fd666fc4ef5763e442c8dab8ee5f27ef99c81eafb4d9779bed158340267859L2876-R2876)
* Updated `get-east-asian-width` from `1.4.0` to `1.5.0` and propagated this change to all relevant snapshots. [[1]](diffhunk://#diff-28fd666fc4ef5763e442c8dab8ee5f27ef99c81eafb4d9779bed158340267859L1145-R1146) [[2]](diffhunk://#diff-28fd666fc4ef5763e442c8dab8ee5f27ef99c81eafb4d9779bed158340267859L3055-R3055) [[3]](diffhunk://#diff-28fd666fc4ef5763e442c8dab8ee5f27ef99c81eafb4d9779bed158340267859L4178-R4178)