### PR TITLE
Rename REPO_ROOT to KAITOSHOME going forward.

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -4,7 +4,7 @@
 Project environment configuration, loaded automatically by direnv.
 
 Sets up:
-  - REPO_ROOT and CI_ENVRC for script imports
+  - KAITOSHOME and CI_ENVRC for script imports
   - Toolchain and Godot version info
   - PATH for local Godot binary
   - Common shell functions (log, import)
@@ -23,8 +23,8 @@ reusable files and functions.
 DOC
 
 # shellcheck disable=SC2155
-export REPO_ROOT="$(git rev-parse --show-toplevel)"
-export CI_ENVRC="source $REPO_ROOT/.envrc"
+export KAITOSHOME="$(git rev-parse --show-toplevel)"
+export CI_ENVRC="source $KAITOSHOME/.envrc"
 
 # TODO: move these over to kaitos.json
 export TOOLCHAIN_NAME="kaitos"
@@ -34,14 +34,14 @@ export GODOT_URL="https://github.com/godotengine/godot/releases/download"
 
 function __envrc__source_global_functions() {
   # shellcheck disable=SC1091
-  source "$REPO_ROOT/scripts/shared/log.api.sh"
+  source "$KAITOSHOME/scripts/shared/log.api.sh"
 
   # shellcheck disable=SC1091
-  source "$REPO_ROOT/scripts/shared/import.func.sh"
+  source "$KAITOSHOME/scripts/shared/import.func.sh"
 }
 
 function __envrc__add_godot_local_path() {
-  export GODOT_LOCAL_PATH="$REPO_ROOT/bin/godot/$GODOT_VERSION"
+  export GODOT_LOCAL_PATH="$KAITOSHOME/bin/godot/$GODOT_VERSION"
 
   # Only add to PATH once to avoid duplicates
   if [[ ":$PATH:" != *":$GODOT_LOCAL_PATH:"* ]]; then

--- a/.github/actions/envrc/action.yaml
+++ b/.github/actions/envrc/action.yaml
@@ -6,6 +6,6 @@ runs:
   steps:
     - shell: bash
       run: |
-        REPO_ROOT="$(git rev-parse --show-toplevel)"
-        echo "CI_ENVRC=source $REPO_ROOT/.envrc" >> "$GITHUB_ENV"
+        KAITOSHOME="$(git rev-parse --show-toplevel)"
+        echo "CI_ENVRC=source $KAITOSHOME/.envrc" >> "$GITHUB_ENV"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"

--- a/scripts/chores/build.sh
+++ b/scripts/chores/build.sh
@@ -44,8 +44,8 @@ EOF
 )"
 
 import \
-  "$REPO_ROOT/scripts/shared/compile.api.sh" \
-  "$REPO_ROOT/scripts/shared/deploy.api.sh"
+  "$KAITOSHOME/scripts/shared/compile.api.sh" \
+  "$KAITOSHOME/scripts/shared/deploy.api.sh"
 
 FLAG_GO=true
 FLAG_RUST=true
@@ -61,7 +61,7 @@ function main() {
     compile_opts[release]=true
   fi
 
-  mkdir -p "$REPO_ROOT/dist"
+  mkdir -p "$KAITOSHOME/dist"
 
   if [[ $FLAG_GO = true ]] && ! compile_go compile_opts; then
     error "Ran into issues compiling go..."

--- a/scripts/chores/bump_git_version.sh
+++ b/scripts/chores/bump_git_version.sh
@@ -33,8 +33,8 @@ EOF
 )"
 
 import \
-  "$REPO_ROOT/scripts/shared/versions.api.sh" \
-  "$REPO_ROOT/scripts/shared/manifest.api.sh"
+  "$KAITOSHOME/scripts/shared/versions.api.sh" \
+  "$KAITOSHOME/scripts/shared/manifest.api.sh"
 
 REGEX_SEMVER='^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z]+(\.[0-9]+)?)?$'
 REGEX_SEMVER_GIT_TAG="^v${REGEX_SEMVER#^}"  # ^v[0-9]+...

--- a/scripts/chores/clean.sh
+++ b/scripts/chores/clean.sh
@@ -28,33 +28,33 @@ FLAG_DOCS=false
 function main() {
   parse_args "$@"
 
-  rm -rf "$REPO_ROOT/temp"
-  rm -rf "$REPO_ROOT/tmp"
-  rm -rf "$REPO_ROOT"/kaitos-*-linux-*
-  rm -rf "$REPO_ROOT"/kaitos-*.tar.gz
+  rm -rf "$KAITOSHOME/temp"
+  rm -rf "$KAITOSHOME/tmp"
+  rm -rf "$KAITOSHOME"/kaitos-*-linux-*
+  rm -rf "$KAITOSHOME"/kaitos-*.tar.gz
 
   if [[ $FLAG_BUILD = true ]]; then
-    rm -rf "$REPO_ROOT/build/" "$REPO_ROOT/dist/"
+    rm -rf "$KAITOSHOME/build/" "$KAITOSHOME/dist/"
   fi
 
   if [[ $FLAG_COVERAGE = true ]]; then
-    rm -rf "$REPO_ROOT/coverage/"
+    rm -rf "$KAITOSHOME/coverage/"
   fi
 
   if [[ $FLAG_RUST = true ]]; then
     shopt -s globstar nullglob
-    rm -rf "$REPO_ROOT"/crates/**/target/
+    rm -rf "$KAITOSHOME"/crates/**/target/
     shopt -u globstar nullglob
   fi
 
   if [[ $FLAG_GO = true ]]; then
-    rm -f "$REPO_ROOT/go/kaitos"
+    rm -f "$KAITOSHOME/go/kaitos"
   fi
 
   if [[ $FLAG_DOCS = true ]]; then
     rm -rf \
-      "$REPO_ROOT/site/.astro" \
-      "$REPO_ROOT/site/dist"
+      "$KAITOSHOME/site/.astro" \
+      "$KAITOSHOME/site/dist"
   fi
 }
 

--- a/scripts/chores/lint.sh
+++ b/scripts/chores/lint.sh
@@ -19,7 +19,7 @@ Notes:
 EOF
 )"
 
-import "$REPO_ROOT/scripts/shared/lint.api.sh"
+import "$KAITOSHOME/scripts/shared/lint.api.sh"
 
 FLAG_RUST=true
 FLAG_GO=true

--- a/scripts/chores/sync_cargo_version.sh
+++ b/scripts/chores/sync_cargo_version.sh
@@ -19,9 +19,9 @@ EOF
 ARG_VERSION=""
 REGEX_SEMVER='^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z]+(\.[0-9]+)?)?$'
 
-import "$REPO_ROOT/scripts/shared/versions.api.sh"
+import "$KAITOSHOME/scripts/shared/versions.api.sh"
 
-PATH_CARGO_WORKSPACE="$REPO_ROOT/crates/Cargo.toml"
+PATH_CARGO_WORKSPACE="$KAITOSHOME/crates/Cargo.toml"
 
 function main() {
   local current_version old_version_line new_version_line

--- a/scripts/chores/sync_docs_version.sh
+++ b/scripts/chores/sync_docs_version.sh
@@ -18,9 +18,9 @@ EOF
 
 ARG_VERSION=""
 
-import "$REPO_ROOT/scripts/shared/versions.api.sh"
+import "$KAITOSHOME/scripts/shared/versions.api.sh"
 
-PATH_DOCS_PACKAGE="$REPO_ROOT/site/package.json"
+PATH_DOCS_PACKAGE="$KAITOSHOME/site/package.json"
 
 function main() {
   local current_version old_version

--- a/scripts/chores/sync_project_manifest.sh
+++ b/scripts/chores/sync_project_manifest.sh
@@ -20,8 +20,8 @@ EOF
 ARG_VERSION=""
 
 import \
-  "$REPO_ROOT/scripts/shared/versions.api.sh" \
-  "$REPO_ROOT/scripts/shared/manifest.api.sh"
+  "$KAITOSHOME/scripts/shared/versions.api.sh" \
+  "$KAITOSHOME/scripts/shared/manifest.api.sh"
 
 function main() {
   local latest

--- a/scripts/chores/sync_readme.sh
+++ b/scripts/chores/sync_readme.sh
@@ -23,7 +23,7 @@ EOF
 )"
 
 import \
-  "$REPO_ROOT/scripts/shared/poke.api.sh"
+  "$KAITOSHOME/scripts/shared/poke.api.sh"
 
 ARG_VERSION=""
 
@@ -50,7 +50,7 @@ function update_readme() {
   local -n __poke__="$1"
   local readme_file new_content tmp_file
 
-  readme_file="$REPO_ROOT/README.md"
+  readme_file="$KAITOSHOME/README.md"
   tmp_file="$(mktemp)"
   new_content="$(generate_pokedex_entry __poke__)"
 

--- a/scripts/chores/test.sh
+++ b/scripts/chores/test.sh
@@ -64,7 +64,7 @@ Runs the rust unit test suite for the project.
 DOC
 function run_rust_tests() {
   log_banner "Rust Unit Tests"
-  cargo test --manifest-path "$REPO_ROOT/crates/Cargo.toml"
+  cargo test --manifest-path "$KAITOSHOME/crates/Cargo.toml"
 }
 
 : <<'DOC'
@@ -72,7 +72,7 @@ Runs the go unit test suite for the project.
 DOC
 function run_go_tests() {
   log_banner "Go Unit Tests"
-  cd "$REPO_ROOT/go" && go test -v ./...
+  cd "$KAITOSHOME/go" && go test -v ./...
 }
 
 main "$@"

--- a/scripts/ci/coverage.sh
+++ b/scripts/ci/coverage.sh
@@ -15,7 +15,7 @@ EOF
 
 function main() {
   parse_args "$@"
-  mkdir -p "$REPO_ROOT/coverage" "$REPO_ROOT/temp"
+  mkdir -p "$KAITOSHOME/coverage" "$KAITOSHOME/temp"
 
   if has_go_changes; then
     run_go_coverage
@@ -65,12 +65,12 @@ function has_rust_changes() {
 function run_go_coverage() {
   local path_tempfile path_cobertura
 
-  path_tempfile="$REPO_ROOT/temp/go_coverage.out"
-  path_cobertura="$REPO_ROOT/coverage/go_coverage.xml"
+  path_tempfile="$KAITOSHOME/temp/go_coverage.out"
+  path_cobertura="$KAITOSHOME/coverage/go_coverage.xml"
 
   log_banner "Go Coverage"
 
-  cd "$REPO_ROOT/go"
+  cd "$KAITOSHOME/go"
   go test -coverprofile="$path_tempfile" ./...
   gocover-cobertura < "$path_tempfile" > "$path_cobertura"
 }
@@ -79,8 +79,8 @@ function run_rust_coverage() {
   log_banner "Rust Coverage"
   cargo llvm-cov \
     --cobertura \
-    --manifest-path "$REPO_ROOT/crates/Cargo.toml" \
-    --output-path "$REPO_ROOT/coverage/rust_coverage.xml"
+    --manifest-path "$KAITOSHOME/crates/Cargo.toml" \
+    --output-path "$KAITOSHOME/coverage/rust_coverage.xml"
 }
 
 main "$@"

--- a/scripts/ci/publish_release.sh
+++ b/scripts/ci/publish_release.sh
@@ -21,9 +21,9 @@ ARG_ARTIFACTS=()
 FLAG_DRY_RUN=false
 
 import \
-  "$REPO_ROOT/scripts/shared/manifest.api.sh" \
-  "$REPO_ROOT/scripts/shared/versions.api.sh" \
-  "$REPO_ROOT/scripts/shared/get_date.func.sh"
+  "$KAITOSHOME/scripts/shared/manifest.api.sh" \
+  "$KAITOSHOME/scripts/shared/versions.api.sh" \
+  "$KAITOSHOME/scripts/shared/get_date.func.sh"
 
 function main() {
   parse_args "$@"

--- a/scripts/shared/compile.api.sh
+++ b/scripts/shared/compile.api.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 eval "${CI_ENVRC:-}"
 
-import "$REPO_ROOT/scripts/shared/cross_platform.api.sh"
+import "$KAITOSHOME/scripts/shared/cross_platform.api.sh"
 
-__compile_api__GO_OUTPUT_PATH="$REPO_ROOT/dist/kaitos"
-__compile_api__RUST_TARGET_DIR="$REPO_ROOT/crates/target"
-__compile_api__RUST_OUTPUT_DIR="$REPO_ROOT/dist/lib"
-__compile_api__RUST_MANIFEST_PATH="$REPO_ROOT/crates/Cargo.toml"
+__compile_api__GO_OUTPUT_PATH="$KAITOSHOME/dist/kaitos"
+__compile_api__RUST_TARGET_DIR="$KAITOSHOME/crates/target"
+__compile_api__RUST_OUTPUT_DIR="$KAITOSHOME/dist/lib"
+__compile_api__RUST_MANIFEST_PATH="$KAITOSHOME/crates/Cargo.toml"
 
 : <<'DOC'
   Compiles the go binary for the project.
@@ -23,7 +23,7 @@ __compile_api__RUST_MANIFEST_PATH="$REPO_ROOT/crates/Cargo.toml"
       Compile the go binary in release mode. Default is false.
 
     options[output_path]: string
-      The path to the output binary. Default is $REPO_ROOT/dist/kaitos.
+      The path to the output binary. Default is $KAITOSHOME/dist/kaitos.
 
   Returns:
     - 0 if the go binary is compiled successfully.
@@ -54,9 +54,9 @@ function compile_go() {
   output_path="${__opts__[output_path]:-$__compile_api__GO_OUTPUT_PATH}"
   mkdir -p "$(dirname "$output_path")" || return 1
 
-  cd "$REPO_ROOT/go" || return 1
+  cd "$KAITOSHOME/go" || return 1
   go build -o "$output_path" "${args[@]}" "./cmd/kaitos.go"
-  cd "$REPO_ROOT" || return 1
+  cd "$KAITOSHOME" || return 1
 }
 
 : <<'DOC'
@@ -73,11 +73,11 @@ function compile_go() {
     options[release]: boolean
       Compile the rust binary in release mode. Default is false.
     options[output_dir]: string
-      The path to the output directory. Default is $REPO_ROOT/dist/lib.
+      The path to the output directory. Default is $KAITOSHOME/dist/lib.
     options[manifest_path]: string
-      The path to the cargo manifest. Default is $REPO_ROOT/crates/Cargo.toml.
+      The path to the cargo manifest. Default is $KAITOSHOME/crates/Cargo.toml.
     options[target_dir]: string
-      The path to the target directory. Default is $REPO_ROOT/crates/target.
+      The path to the target directory. Default is $KAITOSHOME/crates/target.
 
   Returns:
     - 0 if the shared library is compiled and copied successfully.

--- a/scripts/shared/deploy.api.sh
+++ b/scripts/shared/deploy.api.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 eval "${CI_ENVRC:-}"
 
-import "$REPO_ROOT/scripts/shared/cross_platform.api.sh"
+import "$KAITOSHOME/scripts/shared/cross_platform.api.sh"
 
-__deploy_api__DEFAULT_SOURCE_DIR="$REPO_ROOT/dist"
+__deploy_api__DEFAULT_SOURCE_DIR="$KAITOSHOME/dist"
 __deploy_api__XDG_BIN_HOME="${XDG_BIN_HOME:-$HOME/.local/bin}"
 __deploy_api__XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
 __deploy_api__KAITOS_LIB_DIR="$__deploy_api__XDG_DATA_HOME/kaitos/lib"
@@ -21,7 +21,7 @@ __deploy_api__KAITOS_LIB_DIR="$__deploy_api__XDG_DATA_HOME/kaitos/lib"
   Options:
     options[source_dir]: string
       Path to the directory containing built artifacts.
-      Default is $REPO_ROOT/dist.
+      Default is $KAITOSHOME/dist.
 
   Expects source_dir to contain:
     - kaitos                      (CLI binary)
@@ -81,7 +81,7 @@ function deploy_project() {
   Options:
     options[source_dir]: string
       Path to the directory containing built artifacts.
-      Default is $REPO_ROOT/dist.
+      Default is $KAITOSHOME/dist.
 
   Outputs:
     Prints the artifact name (without .tar.gz) to stdout for capture by CI.
@@ -92,10 +92,10 @@ function deploy_project() {
     deploy_system and deploy_project are designed to work outside the repo
     (e.g. a curl|sh bootstrapper that only needs to place artifacts).
     Importing manifest.api.sh here keeps that dependency scoped to bundle,
-    which is only used during builds where $REPO_ROOT is available.
+    which is only used during builds where $KAITOSHOME is available.
 DOC
 function deploy_bundle() {
-  import "$REPO_ROOT/scripts/shared/manifest.api.sh"
+  import "$KAITOSHOME/scripts/shared/manifest.api.sh"
 
   local source_dir version os arch artifact_name
   if [[ -z "${1:-}" ]]; then

--- a/scripts/shared/manifest.api.sh
+++ b/scripts/shared/manifest.api.sh
@@ -5,7 +5,7 @@ eval "${CI_ENVRC:-}"
 API for getting and setting info in the project manifest (kaitos.json)
 DOC
 
-__manifest_api_repo_root="$REPO_ROOT"
+__manifest_api_repo_root="$KAITOSHOME"
 __manifest_api_file="$__manifest_api_repo_root/kaitos.json"
 
 declare -gA __manifest_api_cache

--- a/scripts/shared/poke.api.sh
+++ b/scripts/shared/poke.api.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 eval "${CI_ENVRC:-}"
 
-import "$REPO_ROOT/scripts/shared/manifest.api.sh"
+import "$KAITOSHOME/scripts/shared/manifest.api.sh"
 
 export POKE_START="<!--POKE_INFO_START-->"
 export POKE_END="<!--POKE_INFO_END-->"
@@ -148,7 +148,7 @@ function __poke_api__get_loc() {
   local -n __out__="$1"
   local tokei_json
 
-  tokei_json="$(tokei --output json "$REPO_ROOT")"
+  tokei_json="$(tokei --output json "$KAITOSHOME")"
 
   __out__[go_loc]="$(jq -r '.Go.code // 0' <<< "$tokei_json")"
   __out__[rust_loc]="$(jq -r '.Rust.code // 0' <<< "$tokei_json")"


### PR DESCRIPTION
This pull request standardizes the project root environment variable across the codebase by replacing all instances of `REPO_ROOT` with `KAITOSHOME`. This change affects environment setup, CI/CD scripts, build, test, and utility scripts, as well as documentation references. The update ensures consistency and clarity in how the project root is referenced, reducing confusion and potential errors when sourcing files or defining paths.

This PR is in preparation for https://github.com/kernelle-soft/kaitos-toolchain/issues/60, which will be addressed by adjusting envrc to be used by the forthcoming installer script to do initial setup. KAITOSHOME will be set contextually to either the development path or the setup path, allowing .envrc to act as both the development environment and shim.

**Environment Variable Standardization:**

* All scripts and configuration files now use `KAITOSHOME` instead of `REPO_ROOT` to refer to the project root directory. This includes `.envrc`, shell scripts in `scripts/chores/`, `scripts/ci/`, `scripts/shared/`, and GitHub Actions workflows. [[1]](diffhunk://#diff-d33e979799a45c7c51752e9c8d96a3e452015d1a40b1e4b6ec6a98e92c4d8430L7-R7) [[2]](diffhunk://#diff-d33e979799a45c7c51752e9c8d96a3e452015d1a40b1e4b6ec6a98e92c4d8430L26-R27) [[3]](diffhunk://#diff-5c36a11cde13db6f0c2407209c7025d8bc40165c0dca15da05b844c81c38e68fL9-R10)

**Script and Path Updates:**

* Updated all path references in scripts (such as build, clean, test, deploy, and version sync scripts) to use `KAITOSHOME`, ensuring correct file sourcing and artifact locations throughout the project. [[1]](diffhunk://#diff-736d7a2aa16513fc822f42e0f687832826dc832a64c30ca6f44efaf7618d72b8L47-R48) [[2]](diffhunk://#diff-736d7a2aa16513fc822f42e0f687832826dc832a64c30ca6f44efaf7618d72b8L64-R64) [[3]](diffhunk://#diff-1ac603ca32dbaba8aab8e211264e13f836a0e77c6caa9aa6498ea2ce5451f6d7L31-R57) [[4]](diffhunk://#diff-f62bec6241d5f24eba73273c5c47626af70bfdaa0ea433c3a16ca79cfdc346fbL18-R18) [[5]](diffhunk://#diff-f62bec6241d5f24eba73273c5c47626af70bfdaa0ea433c3a16ca79cfdc346fbL68-R73) [[6]](diffhunk://#diff-f62bec6241d5f24eba73273c5c47626af70bfdaa0ea433c3a16ca79cfdc346fbL82-R83) [[7]](diffhunk://#diff-fcc11adc1e95a4f6a53df44d4914488f371d266bd1b83e9e4d69490c86880b58L24-R26) [[8]](diffhunk://#diff-48ed9c252bda2b568953805f6a4b9f2f63ab760d60e3863a31249ab506b73c7cL36-R37) [[9]](diffhunk://#diff-1ee4a344d8bcd42c871c86b15b5d720e78e4cffa2beea6eb9c6b12ffaf4ec7caL22-R24) [[10]](diffhunk://#diff-b78c47fd00cf77626d41189a667de8ba104c0a5bd1144f3073fa4dd8cae09c43L21-R23) [[11]](diffhunk://#diff-d7c5ad2cfe5c1199e130a3c9c6f35b79d8feefe099ea843eb6ef96e54ac1bedeL23-R24) [[12]](diffhunk://#diff-3e2e4a437cde67f72afc7495fb8d189ebba347665364cf470c1e4d54cfe9e538L26-R26) [[13]](diffhunk://#diff-3e2e4a437cde67f72afc7495fb8d189ebba347665364cf470c1e4d54cfe9e538L53-R53) [[14]](diffhunk://#diff-02bab8d207c355e9fdcff1921d3e6e9514c96133c33607df7518ff41faecb42fL67-R75) [[15]](diffhunk://#diff-8185a1dc2915d6483942f01db1631de6711cdfaeb80aded0c1cd2023ef1df5a0L4-R9) [[16]](diffhunk://#diff-8185a1dc2915d6483942f01db1631de6711cdfaeb80aded0c1cd2023ef1df5a0L26-R26) [[17]](diffhunk://#diff-8185a1dc2915d6483942f01db1631de6711cdfaeb80aded0c1cd2023ef1df5a0L57-R59) [[18]](diffhunk://#diff-8185a1dc2915d6483942f01db1631de6711cdfaeb80aded0c1cd2023ef1df5a0L76-R80) [[19]](diffhunk://#diff-b7d014c32f38884d1770920e1880b189c5f12a97c71954abc5cf8e70f048d643L4-R6) [[20]](diffhunk://#diff-b7d014c32f38884d1770920e1880b189c5f12a97c71954abc5cf8e70f048d643L24-R24) [[21]](diffhunk://#diff-b7d014c32f38884d1770920e1880b189c5f12a97c71954abc5cf8e70f048d643L84-R84) [[22]](diffhunk://#diff-b7d014c32f38884d1770920e1880b189c5f12a97c71954abc5cf8e70f048d643L95-R98) [[23]](diffhunk://#diff-4a7b3d2b30c8e8758ca99836ee93ce473f0f9b11f28b0e2a7312e2f84d16f657L8-R8) [[24]](diffhunk://#diff-93926167fe7c535b021540bc8af8dee2fd1ec194711638d58a70a11f6720de34L4-R4) [[25]](diffhunk://#diff-93926167fe7c535b021540bc8af8dee2fd1ec194711638d58a70a11f6720de34L151-R151) [[26]](diffhunk://#diff-a76e8cd18e3b0e4fc705a03092d9fb38df31a89d9d0021f34c9e7e717330ffe9L22-R22)

**Documentation and Help Text Adjustments:**

* Updated comments, documentation blocks, and help text in scripts to reference `KAITOSHOME` instead of `REPO_ROOT`, maintaining consistency for developers reading or using these scripts. [[1]](diffhunk://#diff-d33e979799a45c7c51752e9c8d96a3e452015d1a40b1e4b6ec6a98e92c4d8430L7-R7) [[2]](diffhunk://#diff-b7d014c32f38884d1770920e1880b189c5f12a97c71954abc5cf8e70f048d643L24-R24) [[3]](diffhunk://#diff-b7d014c32f38884d1770920e1880b189c5f12a97c71954abc5cf8e70f048d643L84-R84) [[4]](diffhunk://#diff-b7d014c32f38884d1770920e1880b189c5f12a97c71954abc5cf8e70f048d643L95-R98) [[5]](diffhunk://#diff-8185a1dc2915d6483942f01db1631de6711cdfaeb80aded0c1cd2023ef1df5a0L26-R26) [[6]](diffhunk://#diff-8185a1dc2915d6483942f01db1631de6711cdfaeb80aded0c1cd2023ef1df5a0L76-R80)

These changes collectively improve maintainability and reduce ambiguity in environment and path management across the entire project.