### PR TITLE
Use the release bot to release (doh)

### DIFF
--- a/.github/workflows/_create_release.yaml
+++ b/.github/workflows/_create_release.yaml
@@ -25,11 +25,22 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
+      - name: Generate Auth Token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
         with:
           ref: main # make sure to get HEAD, instead of triggering commit
+          token: ${{ steps.generate-token.outputs.token }}
 
       - uses: ./.github/actions/envrc
+
+      - name: Configure git
+        run: ./scripts/ci/git_config.sh
 
       - name: Download artifact
         uses: actions/download-artifact@v7
@@ -42,9 +53,6 @@ jobs:
           echo "tag=v$(jq -r '.latest' manifest.json)" >> "$GITHUB_OUTPUT"
           ./scripts/ci/publish_release.sh \
             "${{ needs.build.outputs.artifact }}.tar.gz"
-
-      - name: Configure git
-        run: ./scripts/ci/git_config.sh
 
       - name: Update release index and deploy site
         run: |


### PR DESCRIPTION
This pull request updates the `.github/workflows/_create_release.yaml` workflow to improve authentication and streamline git configuration. The most important changes are grouped by workflow authentication and configuration enhancements:

Workflow authentication improvements:

* Added a step to generate an authentication token using `actions/create-github-app-token@v2`, leveraging GitHub App credentials for improved security.
* Updated the `actions/checkout@v6` step to use the generated token, ensuring all subsequent steps have proper authentication.

Workflow configuration streamlining:

* Moved the `Configure git` step earlier in the workflow, before artifact download, to ensure git is properly configured for all downstream operations. [[1]](diffhunk://#diff-792032d469bcc915a8b9669f30de18678954e3435142a1bce0178c77d0aa48b6R28-R44) [[2]](diffhunk://#diff-792032d469bcc915a8b9669f30de18678954e3435142a1bce0178c77d0aa48b6L46-L48)