### PR TITLE
Extract the PR hygiene workflow to org level

### DIFF
--- a/.github/workflows/pull-request-hygiene.yaml
+++ b/.github/workflows/pull-request-hygiene.yaml
@@ -1,33 +1,9 @@
 name: Pull Request Hygiene
+
 on:
   pull_request:
-    types:
-      - opened
-      - reopened
-      - labeled
-      - unlabeled
-      - assigned
-      - unassigned
+    types: [opened, reopened, labeled, unlabeled, assigned, unassigned]
 
 jobs:
-  check-requirements:
-    name: check-requirements
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Check for assignee
-        if: join(github.event.pull_request.assignees.*.login) == ''
-        run: |
-          echo "ERROR: PR must have at least one assignee"
-          exit 1
-
-      - name: Check for labels
-        if: join(github.event.pull_request.labels.*.name, '') == ''
-        run: |
-          echo "ERROR: PR must have at least one label"
-          exit 1
-
-      - name: Check for description
-        if: ${{ !github.event.pull_request.body }}
-        run: |
-          echo "ERROR: PR must have a description"
-          exit 1
+  hygiene:
+    uses: kernelle-soft/.github/.github/workflows/pull-request-hygiene.yaml@main


### PR DESCRIPTION
This pull request updates the pull request hygiene workflow configuration to use a reusable workflow from a centralized location, simplifying maintenance and ensuring consistency across repositories.

Workflow configuration update:

* Replaced the local `check-requirements` job with the reusable `hygiene` workflow from `kernelle-soft/.github/.github/workflows/pull-request-hygiene.yaml@main`, centralizing hygiene checks.
* Simplified the `types` list for the `pull_request` trigger to use array syntax.